### PR TITLE
Updated enum.sh to use sort -u instead of piping to uniq

### DIFF
--- a/enum.sh
+++ b/enum.sh
@@ -51,7 +51,7 @@ fi
 
 # curl found results
 cat wfuzz.txt | grep -v "404" | grep -o '".*"' | tr -d '"' > ./curl.txt
-sort curl.txt | uniq > curl.txt
+sort -u curl.txt > curl.txt
 
 mkdir curl-requests && cd curl-requests || cd curl-requests
 while IFS="" read -r p || [ -n "$p" ]


### PR DESCRIPTION
Instead of piping sort to uniq, since it seems to be for a GNU standard utils machine simply doing sort -u works just as well.